### PR TITLE
Extend template to cover LuaLaTeX and accessibility tagging

### DIFF
--- a/templates/_pdftemplate/abstractwrapper.tex
+++ b/templates/_pdftemplate/abstractwrapper.tex
@@ -8,6 +8,11 @@
 
 \clearpage
 
+%: if config.latex_engine == 'lualatex'
+\tagstructbegin{tag=Sect}
+%: endif
+
+
 \pagestyle{body}
 
 \pagenumbering{roman}
@@ -23,6 +28,11 @@
 \titleformat{\paragraph}{\normalsize\bfseries\sffamily}{}{0em}{}
 
 \VAR{body}
+
+%: if config.latex_engine == 'lualatex'
+\tagstructend % end abstract/frontmatter section
+%: endif
+
 
 \setcounter{secnumdepth}{4}
 \hypersetup{bookmarksdepth=4}

--- a/templates/_pdftemplate/abstractwrapper.tex
+++ b/templates/_pdftemplate/abstractwrapper.tex
@@ -8,7 +8,7 @@
 
 \clearpage
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructbegin{tag=Sect}
 %: endif
 
@@ -29,7 +29,7 @@
 
 \VAR{body}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructend % end abstract/frontmatter section
 %: endif
 

--- a/templates/_pdftemplate/preface.tex
+++ b/templates/_pdftemplate/preface.tex
@@ -7,7 +7,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \clearpage
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructbegin{tag=Sect}
 %: endif
 
@@ -29,6 +29,6 @@
   \VAR{body}
 
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructend % end preface
 %: endif

--- a/templates/_pdftemplate/preface.tex
+++ b/templates/_pdftemplate/preface.tex
@@ -7,6 +7,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \clearpage
+%: if config.latex_engine == 'lualatex'
+\tagstructbegin{tag=Sect}
+%: endif
+
 
 \pagestyle{body}
 
@@ -21,5 +25,10 @@
 \titleformat{\subsubsection}{\normalsize\bfseries\sffamily}{}{0em}{}
 \titleformat{\paragraph}{\normalsize\bfseries\sffamily}{}{0em}{}
 
-\VAR{body}
 
+  \VAR{body}
+
+
+%: if config.latex_engine == 'lualatex'
+\tagstructend % end preface
+%: endif

--- a/templates/_pdftemplate/references.tex
+++ b/templates/_pdftemplate/references.tex
@@ -5,7 +5,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   References - Unnumbered section
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructbegin{tag=Sect}
 %: endif
 
@@ -19,7 +19,7 @@
 
 \VAR{body}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructend % end references section
 %: endif
 

--- a/templates/_pdftemplate/references.tex
+++ b/templates/_pdftemplate/references.tex
@@ -5,6 +5,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   References - Unnumbered section
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%: if config.latex_engine == 'lualatex'
+\tagstructbegin{tag=Sect}
+%: endif
+
 
 \titleformat{\section}{\normalsize\bfseries\sffamily}{}{0em}{}
 \titleformat{\subsection}{\normalsize\bfseries\sffamily}{}{0em}{}
@@ -14,5 +18,10 @@
 \setcounter{secnumdepth}{-1}
 
 \VAR{body}
+
+%: if config.latex_engine == 'lualatex'
+\tagstructend % end references section
+%: endif
+
 
 \setcounter{secnumdepth}{4}

--- a/templates/_pdftemplate/sectionpart.tex
+++ b/templates/_pdftemplate/sectionpart.tex
@@ -1,17 +1,17 @@
 %%%
-% Section: \VAR{section.name}
+% Section: \VAR{section.name}tex
 % Part:  \VAR{part}
 %%%
 
 % Separate each part in a section with a page break
 \clearpage
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructbegin{tag=Sect}
 %: endif
 
 \VAR{body}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \tagstructend % end body or appendix section
 %: endif

--- a/templates/_pdftemplate/sectionpart.tex
+++ b/templates/_pdftemplate/sectionpart.tex
@@ -6,5 +6,12 @@
 % Separate each part in a section with a page break
 \clearpage
 
+%: if config.latex_engine == 'lualatex'
+\tagstructbegin{tag=Sect}
+%: endif
+
 \VAR{body}
 
+%: if config.latex_engine == 'lualatex'
+\tagstructend % end body or appendix section
+%: endif

--- a/templates/_pdftemplate/sp/cover.tex
+++ b/templates/_pdftemplate/sp/cover.tex
@@ -2,6 +2,10 @@
 
 \hypersetup{bookmarksdepth=-1}
 
+%: if config.latex_engine == 'lualatex'  
+	\tagstructbegin{tag=Sect}
+%: endif
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   Cover Page 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -11,23 +15,59 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % 	Automated based on metadata - delete if not applicable
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\\
-\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\\
-\vfill
+%: if config.latex_engine == 'lualatex'
+	\tagpdfparaOff
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H1}%
+	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\tagmcend\tagstructend \\ \tagstructbegin{tag=H1}\tagmcbegin{tag=H1}
+	\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\tagmcend\tagstructend \\
+	\vfill
+%: else
+	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\\
+	\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\\
+	\vfill
+%: endif
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %	Title 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\Huge{\sffamily{\textbf{\VAR{config.title}}}}\\
+
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=H2}\tagmcbegin{tag=H2}%
+	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\tagmcend\tagstructend\\
+%: else
+	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\\
+%: endif
+
 %: if config.subtitle
-\Large{\sffamily{\VAR{config.subtitle}}}\\
+
+%: if config.latex_engine == 'lualatex'   
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
+	\Large{\sffamily{\VAR{config.subtitle}}}\tagmcend\tagstructend\\
+%: else
+	\Large{\sffamily{\VAR{config.subtitle}}}\\
+%: endif
+
 %: endif
 \vspace{15pt}
 \vfill
 
 %: if config.draft_stage
-\Large{\VAR{config.draft_stage}}
-\vspace{15pt}
-\vfill
+
+%: if config.latex_engine == 'lualatex' 
+	\tagstructbegin{tag=H2}\tagmcbegin{tag=H2}%
+	\Large{\VAR{config.draft_stage}}\tagmcend\tagstructend
+	\vspace{15pt}
+	\vfill
+%: else
+	\Large{\VAR{config.draft_stage}}
+	\vspace{15pt}
+	\vfill
+%: endif
+
+%: endif
+
+%: if config.latex_engine == 'lualatex'
+	\tagpdfparaOn
 %: endif
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -63,8 +103,17 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %	NIST LOGO - keep as-is
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=Figure,alttext=NIST logo}%
+	\tagmcbegin{tag=Figure}%
+	\includegraphics[width=0.5\linewidth]{NIST-logo.eps}\\
+	\tagmcend\tagstructend
 
-\includegraphics[width=0.5\linewidth]{NIST-logo.eps}\\ 
+%: else
+	\includegraphics[width=0.5\linewidth]{NIST-logo.eps}\\
+
+%: endif
+
 
 \end{flushright}
 \end{titlepage}
@@ -81,22 +130,58 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   Publication Series & Number - automated
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\\
-\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\\
-\vfill
+
+%: if config.latex_engine == 'lualatex'
+	\tagpdfparaOff
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H1}%
+	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\tagmcend\tagstructend \\ \tagstructbegin{tag=H1}\tagmcbegin{tag=H1}
+	\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\tagmcend\tagstructend \\
+	\vfill
+%: else
+	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\\
+	\LARGE{\sffamily{\textbf{\VAR{config.long_doc_number}}}}\\
+	\vfill
+%: endif
+	
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %	Title 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\Huge{\sffamily{\textbf{\VAR{config.title}}}}\\
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
+	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\tagmcend\tagstructend\\
+%: else
+	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\\
+%: endif
+
 %: if config.subtitle
-\Large{\sffamily{\VAR{config.subtitle}}}\\
+
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
+	\Large{\sffamily{\VAR{config.subtitle}}}\tagmcend\tagstructend\\
+%: else
+	\Large{\sffamily{\VAR{config.subtitle}}}\\
+%: endif
+
 %: endif
 \vfill
 
 %: if config.draft_stage
-\Large{\VAR{config.draft_stage}}
-\vspace{15pt}
-\vfill
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
+	\Large{\VAR{config.draft_stage}} \tagmcend\tagstructend
+	\vspace{15pt}
+	\vfill
+%: else
+
+	\Large{\VAR{config.draft_stage}}
+	\vspace{15pt}
+	\vfill
+%: endif
+
+%: endif
+
+%: if config.latex_engine == 'lualatex' 
+	\tagpdfparaOn
 %: endif
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -139,8 +224,16 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %  Department of Commerce LOGO - leave as-is
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%	
+%: if config.latex_engine == 'lualatex'
+	\tagstructbegin{tag=Figure,alttext=Department of Commerce logo}%
+	\tagmcbegin{tag=Figure}%
+	\includegraphics[width=0.18\linewidth]{DoC-logo.eps} 
+	\tagmcend\tagstructend
+%: else
+	\includegraphics[width=0.18\linewidth]{DoC-logo.eps} 
+%: endif
 
-\includegraphics[width=0.18\linewidth]{DoC-logo.eps}\\ 
+\\
 \vfill
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %  Department of Commerce & NIST Leadership 
@@ -156,6 +249,12 @@ National Institute of Standards and Technology\\
 
 
 \pagestyle{empty}
+
+%: if config.latex_engine == 'lualatex'
+	\tagstructend % end cover section
+
+	\tagstructbegin{tag=Sect}
+%: endif
 
 \addtocontents{toc}{\setcounter{tocdepth}{-5}} % hide from TOC
 
@@ -186,17 +285,20 @@ Nothing in this publication should be taken to contradict the standards and guid
 
 
 %: if config.approved or config.supersedes
-\section*{Publication History}
+\section*{Publication History} %
 
-\VAR{config.approved}
+\VAR{config.approved} 
 
-\VAR{config.supersedes}
+\VAR{config.supersedes} 
+\par %
 
 %: endif
 
 \section*{How to Cite this NIST Technical Series Publication}
 
+\par %
 \VAR{config.citation} \url{\VAR{config.doi_url}}
+\par %
 
 \section*{Author ORCID iDs}
 
@@ -207,10 +309,9 @@ Nothing in this publication should be taken to contradict the standards and guid
 %: endfor
 
 
-
 %: if config.draft
 
-\section*{Public Comment Period}
+\section*{Public Comment Period} %
 
 \VAR{config.public_comment}
 
@@ -228,5 +329,9 @@ Nothing in this publication should be taken to contradict the standards and guid
 
 
 \normalsize{\bfseries{\sffamily{All comments are subject to release under the Freedom of Information Act (FOIA).}}}
+
+%: if config.latex_engine == 'lualatex'
+	\tagstructend %  end authority section
+%: endif
 
 \hypersetup{bookmarksdepth=4}

--- a/templates/_pdftemplate/sp/cover.tex
+++ b/templates/_pdftemplate/sp/cover.tex
@@ -2,7 +2,7 @@
 
 \hypersetup{bookmarksdepth=-1}
 
-%: if config.latex_engine == 'lualatex'  
+%: if not config.use_pdflatex 
 	\tagstructbegin{tag=Sect}
 %: endif
 
@@ -15,7 +15,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % 	Automated based on metadata - delete if not applicable
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagpdfparaOff
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H1}%
 	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\tagmcend\tagstructend \\ \tagstructbegin{tag=H1}\tagmcbegin{tag=H1}
@@ -31,7 +31,7 @@
 %	Title 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=H2}\tagmcbegin{tag=H2}%
 	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\tagmcend\tagstructend\\
 %: else
@@ -40,7 +40,7 @@
 
 %: if config.subtitle
 
-%: if config.latex_engine == 'lualatex'   
+%: if not config.use_pdflatex  
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
 	\Large{\sffamily{\VAR{config.subtitle}}}\tagmcend\tagstructend\\
 %: else
@@ -53,7 +53,7 @@
 
 %: if config.draft_stage
 
-%: if config.latex_engine == 'lualatex' 
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=H2}\tagmcbegin{tag=H2}%
 	\Large{\VAR{config.draft_stage}}\tagmcend\tagstructend
 	\vspace{15pt}
@@ -66,7 +66,7 @@
 
 %: endif
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagpdfparaOn
 %: endif
 
@@ -103,7 +103,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %	NIST LOGO - keep as-is
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=Figure,alttext=NIST logo}%
 	\tagmcbegin{tag=Figure}%
 	\includegraphics[width=0.5\linewidth]{NIST-logo.eps}\\
@@ -131,7 +131,7 @@
 %   Publication Series & Number - automated
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagpdfparaOff
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H1}%
 	\LARGE{\sffamily{\textbf{NIST \VAR{config.pubseries}}}}\tagmcend\tagstructend \\ \tagstructbegin{tag=H1}\tagmcbegin{tag=H1}
@@ -146,7 +146,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %	Title 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
 	\Huge{\sffamily{\textbf{\VAR{config.title}}}}\tagmcend\tagstructend\\
 %: else
@@ -155,7 +155,7 @@
 
 %: if config.subtitle
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
 	\Large{\sffamily{\VAR{config.subtitle}}}\tagmcend\tagstructend\\
 %: else
@@ -166,7 +166,7 @@
 \vfill
 
 %: if config.draft_stage
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=H1}\tagmcbegin{tag=H2}%
 	\Large{\VAR{config.draft_stage}} \tagmcend\tagstructend
 	\vspace{15pt}
@@ -180,7 +180,7 @@
 
 %: endif
 
-%: if config.latex_engine == 'lualatex' 
+%: if not config.use_pdflatex
 	\tagpdfparaOn
 %: endif
 
@@ -224,7 +224,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %  Department of Commerce LOGO - leave as-is
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%	
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructbegin{tag=Figure,alttext=Department of Commerce logo}%
 	\tagmcbegin{tag=Figure}%
 	\includegraphics[width=0.18\linewidth]{DoC-logo.eps} 
@@ -250,7 +250,7 @@ National Institute of Standards and Technology\\
 
 \pagestyle{empty}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructend % end cover section
 
 	\tagstructbegin{tag=Sect}
@@ -330,7 +330,7 @@ Nothing in this publication should be taken to contradict the standards and guid
 
 \normalsize{\bfseries{\sffamily{All comments are subject to release under the Freedom of Information Act (FOIA).}}}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 	\tagstructend %  end authority section
 %: endif
 

--- a/templates/_pdftemplate/sp/toc.tex
+++ b/templates/_pdftemplate/sp/toc.tex
@@ -3,6 +3,43 @@
 % 	List of Tables & Figures required if more than 5 tables/figures
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%: if config.latex_engine == 'lualatex'
+
+\clearpage
+
+\tagstructbegin{tag=Sect}
+
+\begin{center}
+
+\titleformat{\section}{\large\bfseries\sffamily}{}{1em}{}
+
+\hypersetup{linkcolor=black}
+
+%%%%% Main TOC 
+\tagstructbegin{tag=TOC}
+\tableofcontents
+\tagstructend % end main toc
+
+\appendixtitleon
+\appendixtitletocon
+
+%%%%% Tables TOC  
+\tagstructbegin{tag=TOC}
+\listoftables
+\tagstructend % end tables toc
+
+%%%%% Figures TOC
+  \tagstructbegin{tag=TOC}
+  \listoffigures
+  \tagstructend % end figures toc
+
+\end{center}
+\clearpage
+\tagstructend % end toc section
+
+%: else
+
+% pdflatex version of ToC
 \clearpage
 
 \begin{center}
@@ -19,3 +56,10 @@
 
 \end{center}
 \clearpage
+
+
+%: endif
+
+
+
+

--- a/templates/_pdftemplate/sp/toc.tex
+++ b/templates/_pdftemplate/sp/toc.tex
@@ -3,7 +3,7 @@
 % 	List of Tables & Figures required if more than 5 tables/figures
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 
 \clearpage
 

--- a/templates/_pdftemplate/template.tex
+++ b/templates/_pdftemplate/template.tex
@@ -4,6 +4,16 @@
 % 	Original SP template developed by K. Miller, kmm5@nist.gov 
 %	Last updated: 26-March-2019
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% pdfmanagement is required for tagpdf
+%: if config.latex_engine == 'lualatex'
+\RequirePackage{pdfmanagement-testphase}
+\DocumentMetadata
+{
+ testphase = phase-I, % tagging without paragraph tagging
+ testphase = phase-II % tagging with paragraph tagging and other new stuff.
+}
+%: endif
+
 \documentclass[12pt]{article}
 \usepackage{mathptmx}
 \usepackage{pifont}
@@ -21,8 +31,14 @@
 \usepackage{float}
 \usepackage[utf8]{inputenc}
 \usepackage{textcomp}
-\usepackage[hang,flushmargin,bottom]{footmisc} % footnote format
-\usepackage{microtype}
+
+%: if config.latex_engine == 'lualatex'
+  \usepackage[flushmargin,bottom]{footmisc} % hang option breaks tagpdf with lualatex
+%: else
+  \usepackage[hang,flushmargin, bottom]{footmisc} % footnote format
+  \usepackage{microtype} % not needed since Lualatex can disable ligatures through fontspec
+%: endif
+
 \usepackage{etoolbox} % for switching sections on and off
 \usepackage{longtable}
 \usepackage{tabularx}
@@ -37,11 +53,37 @@
 \usepackage[titletoc,title]{appendix}
 \usepackage{multicol}
 
-\DisableLigatures[f,l,i]{encoding = *, family = *}
+%: if config.latex_engine == 'lualatex'
+  \usepackage{tagpdf}
+  \usepackage{fontspec} %for fonts with lualatex fonts
+  \usepackage{polyglossia}
+  \tagpdfsetup{uncompress,activate-all,paratagging,log=v}
+  \defaultfontfeatures{Ligatures=NoCommon}
+%: else
+  % disabling ligatures in pdflatex
+  \DisableLigatures[f,l,i]{encoding = *, family = *} 
+%: endif
+
 
 % Command for inverting the color on table and diagram headers
 \newcommand{\colorsection}[1]{%
   \colorbox{black}{\noindent\parbox{\dimexpr\textwidth-2\fboxsep}{\color{white}\ #1}}}
+  
+ 
+%: if config.latex_engine == 'lualatex'
+  % Define language and fonts
+  % Use the tex-gyre families
+  \setdefaultlanguage{english}
+  \setmainlanguage[]{english}
+  \setmainfont{TeX Gyre Termes}
+  % Optionally set \sffamily and \ttfamily font families
+  \setsansfont{TeX Gyre Heros}
+  \setmonofont{TeX Gyre Cursor}
+
+  % may need to separately \setmathfont 
+
+%: endif
+
 
 
 % Set up multi-page long tables, inclue with {:latex-longtable="true"} flag following table
@@ -69,6 +111,97 @@
 \def\endltabulary{\endtabulary}
 
 \makeatother
+
+
+%: if config.latex_engine == 'lualatex'
+  % for section struct tagging
+  % From Ulrike Fischer
+  %    -Creator of tagpdf- https://github.com/u-fischer/tagpdf
+  % https://tex.stackexchange.com/a/614050
+  % Note: This will likely become unncessary in future updates to LaTeX 
+  \NewCommandCopy\oldsection\section
+  \RenewDocumentCommand\section{som}
+   {%
+     \par%ensure that you are in vmode
+     \tagpdfparaOff\tagstructbegin{tag=H1}\tagmcbegin{tag=H1}%
+     \IfBooleanTF {#1}%test the star
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsection*[#2]{#3}}
+       {\oldsection*{#3}}%
+     }  
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsection[#2]{#3}}
+       {\oldsection{#3}}%
+     }%
+    \tagmcend\tagstructend\tagpdfparaOn 
+  }
+
+  % for section struct tagging
+  \NewCommandCopy\oldsubsection\subsection
+  \RenewDocumentCommand\subsection{som}
+   {%
+     \par%ensure that you are in vmode
+     \tagpdfparaOff\tagstructbegin{tag=H2}\tagmcbegin{tag=H2}%
+     \IfBooleanTF {#1}%test the star
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsubsection*[#2]{#3}}
+       {\oldsubsection*{#3}}%
+     }  
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsubsection[#2]{#3}}
+       {\oldsubsection{#3}}%
+     }%
+    \tagmcend\tagstructend\tagpdfparaOn 
+  }
+
+  % for subsubsection struct tagging
+  \NewCommandCopy\oldsubsubsection\subsubsection
+  \RenewDocumentCommand\subsubsection{som}
+   {%
+     \par%ensure that you are in vmode
+     \tagpdfparaOff\tagstructbegin{tag=H3}\tagmcbegin{tag=H3}%
+     \IfBooleanTF {#1}%test the star
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsubsubsection*[#2]{#3}}
+       {\oldsubsubsection*{#3}}%
+     }  
+     {%
+      \IfValueTF{#2}% test the optional argument
+       {\oldsubsubsection[#2]{#3}}
+       {\oldsubsubsection{#3}}%
+     }%
+    \tagmcend\tagstructend\tagpdfparaOn 
+  }
+
+  % for paragraph struct tagging
+  \NewCommandCopy\oldparagraph\paragraph
+  \RenewDocumentCommand\paragraph{som}
+  {%
+    \par%ensure that you are in vmode
+    \tagpdfparaOff\tagstructbegin{tag=H4}\tagmcbegin{tag=H4}%
+    \IfBooleanTF {#1}%test the star
+    {%
+      \IfValueTF{#2}% test the optional argument
+      {\oldparagraph*[#2]{#3}}
+      {\oldparagraph*{#3}}%
+    }  
+    {%
+      \IfValueTF{#2}% test the optional argument
+      {\oldparagraph[#2]{#3}}
+      {\oldparagraph{#3}}%
+    }%
+    \tagmcend\tagstructend\tagpdfparaOn 
+  }
+
+%: endif
+
+
+
 % End macros 
 
 %: if config.watermark
@@ -96,6 +229,17 @@
 
 % Turn on line numbering
 \usepackage{lineno}
+ 
+%: if config.latex_engine == 'lualatex'
+   % tag page numbers as artifacts
+   % use actualtext attribute on line numbers to make them logical blanks
+   % actualtext currently only works in span tags, so this doesn't work
+  \renewcommand{\makeLineNumber}{
+    \tagmcbegin{artifact=pagination}\hss\linenumberfont\LineNumber\hskip\linenumbersep\tagmcend
+  }
+%: endif
+
+
 \linenumbers
 
 %: endif
@@ -242,13 +386,28 @@ pdfdisplaydoctitle = true
 \DeclareCaptionFont{helvet}{\small\sffamily\selectfont}
 \captionsetup{labelfont=bf,labelsep=period,font=helvet,figurename=Fig.,justification=raggedright}
 
+
+%: if config.latex_engine != 'lualatex'
 \pdfminorversion=7
+%: endif
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   	BEGIN DOCUMENT 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}
     \RaggedRight % left-justification universal
+
+%: if config.latex_engine == 'lualatex'
+  %lualatex uses pdfvariable instead
+  % set pdf version using new commands for Lualatex
+  % keep this after begin document  
+  \pdfvariable majorversion 1
+  \pdfvariable minorversion 7
+%: endif
+
+% pdflatex sets the pdf version above the "begin{document}"
+
+
 
 \VAR{rendered.cover}
 
@@ -279,5 +438,7 @@ pdfdisplaydoctitle = true
 \VAR{rendered.appendix}
 
 %: endif
+
+% tagpdf automatically adds \tagstructend  for end document
 
 \end{document}

--- a/templates/_pdftemplate/template.tex
+++ b/templates/_pdftemplate/template.tex
@@ -5,7 +5,7 @@
 %	Last updated: 26-March-2019
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % pdfmanagement is required for tagpdf
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
 \RequirePackage{pdfmanagement-testphase}
 \DocumentMetadata
 {
@@ -32,7 +32,7 @@
 \usepackage[utf8]{inputenc}
 \usepackage{textcomp}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
   \usepackage[flushmargin,bottom]{footmisc} % hang option breaks tagpdf with lualatex
 %: else
   \usepackage[hang,flushmargin, bottom]{footmisc} % footnote format
@@ -53,7 +53,7 @@
 \usepackage[titletoc,title]{appendix}
 \usepackage{multicol}
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
   \usepackage{tagpdf}
   \usepackage{fontspec} %for fonts with lualatex fonts
   \usepackage{polyglossia}
@@ -70,7 +70,7 @@
   \colorbox{black}{\noindent\parbox{\dimexpr\textwidth-2\fboxsep}{\color{white}\ #1}}}
   
  
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
   % Define language and fonts
   % Use the tex-gyre families
   \setdefaultlanguage{english}
@@ -113,7 +113,7 @@
 \makeatother
 
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
   % for section struct tagging
   % From Ulrike Fischer
   %    -Creator of tagpdf- https://github.com/u-fischer/tagpdf
@@ -230,7 +230,7 @@
 % Turn on line numbering
 \usepackage{lineno}
  
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
    % tag page numbers as artifacts
    % use actualtext attribute on line numbers to make them logical blanks
    % actualtext currently only works in span tags, so this doesn't work
@@ -387,7 +387,7 @@ pdfdisplaydoctitle = true
 \captionsetup{labelfont=bf,labelsep=period,font=helvet,figurename=Fig.,justification=raggedright}
 
 
-%: if config.latex_engine != 'lualatex'
+%: if config.use_pdflatex
 \pdfminorversion=7
 %: endif
 
@@ -397,7 +397,7 @@ pdfdisplaydoctitle = true
 \begin{document}
     \RaggedRight % left-justification universal
 
-%: if config.latex_engine == 'lualatex'
+%: if not config.use_pdflatex
   %lualatex uses pdfvariable instead
   % set pdf version using new commands for Lualatex
   % keep this after begin document  


### PR DESCRIPTION
This extends the LaTeX template to support the existing pdflatex build path as well as the new LuaLaTeX path that performs automatic accessibility tagging.

It uses the Jinja commands supported by the build tools to include pdflatex and lualatex-specific LaTeX macros based on the configuration specified in the `_pdf.yml` file.  In particular, it checks if the `latex_engine:` has been set to `lualatex`. Otherwise it defaults to the pdflatex path.

The related docker image does not support both paths, so at least as of right now, the `docker-compose-pdf.yml` would need to specify the right image to use.  The current `csd773/nistpages-pdf:lualatex`  image should work. (https://hub.docker.com/r/csd773/nistpages-pdf)