### PR TITLE
add switch for list of tables and figures

### DIFF
--- a/templates/_pdftemplate/sp/toc.tex
+++ b/templates/_pdftemplate/sp/toc.tex
@@ -14,8 +14,12 @@
     \tableofcontents
 	\appendixtitleon
     \appendixtitletocon
+%: if not config.skiptabletoc
     \listoftables
+%: endif
+%: if not config.skipfiguretoc
     \listoffigures
+%: endif
 
 \end{center}
 \clearpage


### PR DESCRIPTION
Adds two configuration switches to turn off the list of tables and list of figures, if they're empty:

- skiptabletoc

- skipfiguretoc


